### PR TITLE
Fixed missing locale param in jsp that use i18n bundles

### DIFF
--- a/src/main/webapp/pages/config.jsp
+++ b/src/main/webapp/pages/config.jsp
@@ -19,7 +19,7 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="portlet" uri="http://java.sun.com/portlet" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 
 <%@ page import="java.util.List" %>
@@ -38,7 +38,10 @@ heights.add(String.valueOf(Constants.PORTLET_HEIGHT_1600));
 pageContext.setAttribute("heights",heights);
 %>
 
-<portlet:defineObjects /> 
+<portlet:defineObjects />
+
+<c:set var="language" value="${not empty param.language ? param.language : not empty language ? language : pageContext.request.locale}" scope="request" />
+<fmt:setLocale value="${language}" />
 <fmt:setBundle basename="au.edu.anu.portal.portlets.basiclti.utils.messages" />
 
 <style type="text/css">

--- a/src/main/webapp/pages/edit.jsp
+++ b/src/main/webapp/pages/edit.jsp
@@ -19,7 +19,7 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="portlet" uri="http://java.sun.com/portlet" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jstl/fmt" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 
 
 <%@ page import="java.util.List" %>
@@ -39,6 +39,9 @@ pageContext.setAttribute("heights",heights);
 %>
 
 <portlet:defineObjects /> 
+
+<c:set var="language" value="${not empty param.language ? param.language : not empty language ? language : pageContext.request.locale}" scope="request" />
+<fmt:setLocale value="${language}" />
 <fmt:setBundle basename="au.edu.anu.portal.portlets.basiclti.utils.messages" />
 
 <style type="text/css">


### PR DESCRIPTION
Fixed missing locale param in jsp that use i18n bundles
