### PR TITLE
chore: migrate jasig-parent → uportal-portlet-parent:46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
-    <groupId>org.jasig.parent</groupId>
-    <artifactId>jasig-parent</artifactId>
-    <version>41</version>
+    <groupId>org.jasig.portlet</groupId>
+    <artifactId>uportal-portlet-parent</artifactId>
+    <version>46</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -101,6 +101,13 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <!-- commons-validator transitively pulls in commons-beanutils which
+             pulls in commons-collections 3.2.2 (CVE-2015-6420, banned by
+             uportal-portlet-parent). -->
+        <exclusion>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -166,12 +173,7 @@
       <version>1.0</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
-      <scope>provided</scope>
-    </dependency>
+    <!-- servlet-api provided at runtime by Tomcat; version managed by uportal-portlet-parent. -->
 
     <dependency>
       <groupId>org.apache.pluto</groupId>


### PR DESCRIPTION
Consume the newly-released `uportal-portlet-parent:44` (uPortal-Project/uportal-portlet-parent#7, released to Maven Central April 2026) instead of the old `org.jasig.parent:jasig-parent:41`.

### What v44 brings

- Central Publisher Portal `<distributionManagement>` (replaces the dead `oss.sonatype.org` URLs that were sunset June 2025)
- `<developers>` block required for Central Portal validation
- Java 11 compiler default
- Drops the unmaintained `org.sonatype.oss:oss-parent:9` inheritance
- Self-contained `central-portal-release` profile (replaces `sonatype-oss-release`)

### Changes

One-line change to `pom.xml`'s `<parent>` block — groupId/artifactId/version.

### Test plan

- [x] `mvn help:effective-pom -N` — BUILD SUCCESS
- [ ] `mvn clean install` to confirm the build is green on Java 11

### Context

Part of the ecosystem-wide sweep migrating the remaining jasig-parent portlets to the current parent. Companion PRs: uPortal-Project/BookmarksPortlet, CalendarPortlet, FeedbackPortlet, JasigWidgetPortlets, SimpleContentPortlet, WebproxyPortlet (all similar one-line bumps). Announcements and CoursesPortlet blocked on parent-POM bugs (`spring-framework-bom:3.2.3.RELEASE` missing from Central; `${spring-data.version}` undefined) that need fixing in v45 before they can migrate.