### PR TITLE
chore: renovate — block plexus-archiver 4.11+ until war-plugin bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "matchPackageNames": ["javax.portlet:portlet-api"],
       "allowedVersions": "< 3.0",
       "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is incompatible with the container."
+    },
+    {
+      "matchPackageNames": ["org.codehaus.plexus:plexus-archiver"],
+      "allowedVersions": "< 4.11.0",
+      "description": "plexus-archiver 4.11+ requires a newer commons-io (BoundedInputStream.builder()) than the one bundled with maven-war-plugin 3.4.0 (pinned by uportal-portlet-parent). Revisit once the parent bumps maven-war-plugin to 3.5.x+."
     }
   ]
 }


### PR DESCRIPTION
## Summary

`plexus-archiver:4.11` introduced a call to `commons-io`'s `BoundedInputStream.builder()`, which only exists in a newer `commons-io` than the one `maven-war-plugin:3.4.0` bundles. Since `uportal-portlet-parent:48` pins `maven-war-plugin` at 3.4.0, any 4.11+ upgrade of `plexus-archiver` breaks the war build with:

```
NoSuchMethodError: org.apache.commons.io.input.BoundedInputStream.builder()
```

Pin `plexus-archiver < 4.11` until the parent bumps `maven-war-plugin` to 3.5.x+, at which point this rule can come out.

**Closes** #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)