### PR TITLE
chore: bump parent to v49 and inherit license-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>48</version>
+    <version>49</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -212,31 +212,6 @@
             <version>4.9.2</version>
           </dependency>
         </dependencies>
-      </plugin>
-
-      <!-- License plugin, specific for this portlet -->
-      <plugin>
-        <groupId>com.mycila.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
-        <version>1.9.0</version>
-        <configuration>
-          <basedir>${basedir}</basedir>
-          <header>docs/apache-license-2-template.txt</header>
-          <properties>
-            <year>${project.inceptionYear}-2013</year>
-            <holder>The Australian National University</holder>
-          </properties>
-          <encoding>UTF-8</encoding>
-          <strictCheck>true</strictCheck>
-          <excludes>
-            <exclude>LICENSE</exclude>
-            <exclude>NOTICE</exclude>
-            <exclude>docs/**</exclude>
-            <exclude>**/*.properties</exclude>
-            <exclude>**/*.xml</exclude>
-            <exclude>README.md</exclude>
-          </excludes>
-        </configuration>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
## Summary

Drops the legacy local `com.mycila.maven-license-plugin:maven-license-plugin:1.9.0` block and bumps to parent v49 to inherit the modern `com.mycila:license-maven-plugin:2.11`. Closes the per-portlet license-plugin migration that's been on the fleet's followup list since the v48 audit.

## Why

basiclti-portlet was the only repo in the 11-portlet fleet still declaring its own license plugin block. It pinned the legacy `com.mycila.maven-license-plugin` coordinate — the pre-rename artifact ID, last released as 1.9.0 in 2013 — and pointed `<header>` at `docs/apache-license-2-template.txt`, a custom template carrying ANU (Australian National University) branding from the pre-donation days.

The local block was vestigial in two ways:
1. The actual source files **already use the canonical Apereo header** (`Licensed to Apereo under one or more contributor license agreements...`) — verified across all .java files. The `docs/apache-license-2-template.txt` template was no longer in use, just referenced.
2. Five of the six local excludes (`LICENSE`, `NOTICE`, `docs/**`, `**/*.properties`, `**/*.xml`, `README.md`) were either redundant with parent v49 (LICENSE, NOTICE, docs/**) or over-broad blanket exclusions the modern strict-check doesn't need.

So: drop the block, inherit parent's plugin, run `license:check` to confirm. No source changes required.

## Changes

`pom.xml`:
- Parent `48` → `49`.
- Delete the entire 27-line legacy `com.mycila.maven-license-plugin` `<plugin>` block, including the ANU copyright placeholder properties.


## What's NOT in this PR

- `docs/apache-license-2-template.txt` is now unreferenced but left in place. Separate cleanup, no functional impact (parent excludes `docs/**` from license check).

## Supersedes #64

Renovate PR #64 (parent `48` → `49`) only bumps the parent version and would leave the legacy plugin block in place — defeating the purpose of v49's license-plugin defaults. Once this PR merges, Renovate will close #64 automatically.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green against parent v49's inherited config
- [ ] CI on the Java 11 matrix
