### PR TITLE
chore: bump parent v50 → v51 and migrate commons-lang → commons-lang3 + commons-text

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,27 +16,25 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
+  Apache Commons BeanUtils under Apache-2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Lang under Apache-2.0
+  Apache Commons Text under Apache-2.0
+  Apache Commons Validator under Apache-2.0
+  Apache HttpClient under Apache License, Version 2.0
+  Apache HttpCore under Apache License, Version 2.0
   Basic LTI Portlet under The Apache Software License, Version 2.0
-  Collections under Apache License, Version 2.0
-  Commons Codec under The Apache Software License, Version 2.0
-  Commons Lang under The Apache Software License, Version 2.0
-  commons-beanutils under Apache License, Version 2.0
-  commons-digester under Apache License, Version 2.0
+  Commons Digester under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
-  HttpClient under Apache License
-  HttpCore under Apache License
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  JCL 1.2 implemented over SLF4J under Apache-2.0
   jstl under Commons Development and Distribution License, Version 1.0
-  JUL to SLF4J bridge under MIT License
-  Log4j Implemented Over SLF4J under Apache Software Licenses
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  JUL to SLF4J bridge under MIT
+  Log4j Implemented Over SLF4J under Apache-2.0
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   OAuth Core under The Apache Software License, Version 2.0
   Pluto Portlet Tag Library under The Apache Software License, Version 2.0
   Portlet API under Commons Development and Distribution License, Version 1.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   standard under Apache License, Version 2.0
-  Validator under The Apache Software License, Version 2.0
-  XML Commons External Components XML APIs under The Apache Software License, Version 2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>50</version>
+    <version>51</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -83,8 +83,12 @@
       <artifactId>standard</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-validator</groupId>

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/BasicLTIPortlet.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/BasicLTIPortlet.java
@@ -45,8 +45,8 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/BasicLTIPortlet.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/BasicLTIPortlet.java
@@ -274,7 +274,7 @@ public class BasicLTIPortlet extends GenericPortlet{
 		//get prefs and submitted values
 		PortletPreferences prefs = request.getPreferences();
 		String portletHeight = request.getParameter("portletHeight");
-		String portletTitle = StringEscapeUtils.escapeHtml(StringUtils.trim(request.getParameter("portletTitle")));
+		String portletTitle = StringEscapeUtils.escapeHtml4(StringUtils.trim(request.getParameter("portletTitle")));
 		
 		
 		//validate

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/adapters/PeoplesoftAdapter.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/adapters/PeoplesoftAdapter.java
@@ -20,7 +20,7 @@ package au.edu.anu.portal.portlets.basiclti.adapters;
 
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/adapters/SakaiAdapter.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/adapters/SakaiAdapter.java
@@ -20,7 +20,7 @@ package au.edu.anu.portal.portlets.basiclti.adapters;
 
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/support/CollectionsSupport.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/support/CollectionsSupport.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/support/HttpSupport.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/support/HttpSupport.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.http.HttpResponse;

--- a/src/main/java/au/edu/anu/portal/portlets/basiclti/support/HttpSupport.java
+++ b/src/main/java/au/edu/anu/portal/portlets/basiclti/support/HttpSupport.java
@@ -146,8 +146,8 @@ public class HttpSupport {
 		text.append("<div id=\"ltiLaunchFormSubmitArea\">\n");
         text.append("<form action=\""+address+"\" name=\"ltiLaunchForm\" id=\"ltiLaunchForm\" method=\"post\" encType=\"application/x-www-form-urlencoded\">\n" );
         for (Map.Entry<String,String> entry : params.entrySet()) {
-        	String key = StringEscapeUtils.escapeHtml(entry.getKey());
-        	String value = StringEscapeUtils.escapeHtml(entry.getValue());
+        	String key = StringEscapeUtils.escapeHtml4(entry.getKey());
+        	String value = StringEscapeUtils.escapeHtml4(entry.getValue());
 	
         	if ( key.equals(BASICLTI_SUBMIT) ) {
                  text.append("<input type=\"submit\" name=\"");


### PR DESCRIPTION
Supersedes #67. Bumps to [uportal-portlet-parent:51](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-51) and migrates the source/dependency declarations off the EOL `commons-lang 2.x` line (CVE-2025-48924) onto `commons-lang3:3.20.0` + `commons-text:1.15.0`.

A bare parent-bump PR (#67) failed CI because v51 drops the `commons-lang` dM entry; without the lang3 source migration in the same PR, the build can't resolve the still-declared `<dependency>commons-lang:commons-lang</>` (no version). #67 was closed in favor of this combined PR.

## Why

Parent v51 replaced `commons-lang 2.6` (EOL, no upstream fix for CVE-2025-48924) with `commons-lang3 3.20.0` and added `commons-text 1.15.0` (the post-2017 home of `StringEscapeUtils`). basiclti uses `StringUtils` and `StringEscapeUtils` in source and declares `commons-lang` in its pom; both need migration.

## Changes

`pom.xml`:
- `<parent><version>50</version></>` → `<version>51</version>`.
- Swap `commons-lang:commons-lang` for `org.apache.commons:commons-lang3`.
- Add `org.apache.commons:commons-text` for the `StringEscapeUtils` import.

Source (5 .java files, mostly mechanical):
- `org.apache.commons.lang.StringUtils` → `org.apache.commons.lang3.StringUtils` (`BasicLTIPortlet`, `PeoplesoftAdapter`, `SakaiAdapter`, `CollectionsSupport`).
- `org.apache.commons.lang.StringEscapeUtils` → `org.apache.commons.text.StringEscapeUtils` (`HttpSupport`).
- `StringEscapeUtils.escapeHtml(...)` → `StringEscapeUtils.escapeHtml4(...)` — commons-text 1.x renamed the HTML escape method to be explicit about target spec; HTML 4 preserves the prior commons-lang 2.6 semantics.

`NOTICE`: regenerated to reflect the lang3/commons-text dep change.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn notice:check` — green
- [x] `mvn license:check` — green
- [ ] CI on Java 11 matrix